### PR TITLE
check provider stake

### DIFF
--- a/launchmevcommit
+++ b/launchmevcommit
@@ -125,7 +125,7 @@ server_pid=$!
 sleep 3
 
 KEY=$(cat $ROOT_DIRECTORY/key)
-ADDRESS=$(cast wallet address --private-key 0x$(cat $ROOT_DIRECTORY/key))
+ADDRESS=$($HOME/.foundry/bin/cast wallet address --private-key 0x$(cat $ROOT_DIRECTORY/key))
 
 echo -e "\033[31m[\033[34m*\033[31m]\033[33m Created private key and saved.\033[0m"
 echo -e "\033[31m[\033[34m*\033[31m]\033[33m Wallet Address: $ADDRESS \033[0m"

--- a/launchmevcommit
+++ b/launchmevcommit
@@ -138,13 +138,22 @@ fi
 
 # Check i Node_Type is provider
 if [ "$NODE_TYPE" == "provider" ]; then
-    echo -e "\033[31m[\033[34m*\033[31m]\033[33m Registering $ADDRESS as a provider with 50 ether stake \033[0m"
+    
+    stake_amount=$($HOME/.foundry/bin/cast call $PROVIDER_REGISTRY_CONTRACT 'checkStake(address)' $ADDRESS --rpc-url http://69.67.151.95:8545)
 
-    # Use the RPC URL variable in the cast send command
-    if ! $HOME/.foundry/bin/cast send $PROVIDER_REGISTRY_CONTRACT "registerAndStake()" $ADDRESS --rpc-url http://69.67.151.95:8545 --private-key $KEY --value 50ether > /dev/null 2>&1; then
-            echo "Failed to send provider registration transaction."
-            exit 1
+    if [[ $stake_amount =~ ^0x0+$ ]]; then
+	echo -e "\033[31m[\033[34m*\033[31m]\033[33m Registering $ADDRESS as a provider with 50 ether stake \033[0m"
+
+   	# Use the RPC URL variable in the cast send command
+   	if ! $HOME/.foundry/bin/cast send $PROVIDER_REGISTRY_CONTRACT "registerAndStake()" $ADDRESS --rpc-url http://69.67.151.95:8545 --private-key $KEY --value 50ether > /dev/null 2>&1; then
+   	        echo "Failed to send provider registration transaction."
+   	        exit 1
+   	fi
+    else
+	echo -e "\033[31m[\033[34m*\033[31m]\033[33m The address $ADDRESS is already registered as provider \033[0m"
     fi
+
+
 else
     echo -e "\033[31m[\033[34m*\033[31m]\033[33m Adding a prepay for bidder with $ADDRESS \033[0m"
 

--- a/launchmevcommit
+++ b/launchmevcommit
@@ -139,13 +139,13 @@ fi
 # Check i Node_Type is provider
 if [ "$NODE_TYPE" == "provider" ]; then
     
-    stake_amount=$($HOME/.foundry/bin/cast call $PROVIDER_REGISTRY_CONTRACT 'checkStake(address)' $ADDRESS --rpc-url http://69.67.151.95:8545)
+    stake_amount=$($HOME/.foundry/bin/cast call $PROVIDER_REGISTRY_CONTRACT 'checkStake(address)' $ADDRESS --rpc-url $RPC_URL)
 
     if [[ $stake_amount =~ ^0x0+$ ]]; then
 	echo -e "\033[31m[\033[34m*\033[31m]\033[33m Registering $ADDRESS as a provider with 50 ether stake \033[0m"
 
    	# Use the RPC URL variable in the cast send command
-   	if ! $HOME/.foundry/bin/cast send $PROVIDER_REGISTRY_CONTRACT "registerAndStake()" $ADDRESS --rpc-url http://69.67.151.95:8545 --private-key $KEY --value 50ether > /dev/null 2>&1; then
+   	if ! $HOME/.foundry/bin/cast send $PROVIDER_REGISTRY_CONTRACT "registerAndStake()" $ADDRESS --rpc-url $RPC_URL --private-key $KEY --value 50ether > /dev/null 2>&1; then
    	        echo "Failed to send provider registration transaction."
    	        exit 1
    	fi


### PR DESCRIPTION
If the provider peer is already registered, it generates the following error and the launch script does not work properly

(code: 3, message: execution reverted: Provider already registered, data: Some(String("0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000
0000000000001b50726f766964657220616c726561647920726567697374657265640000000000")))